### PR TITLE
Add SNMP and OPC-UA support

### DIFF
--- a/assets/opcua-template-config.toml
+++ b/assets/opcua-template-config.toml
@@ -1,0 +1,31 @@
+log_level = "debug"
+log_format = "text" # output log format (you can use text or json)
+auto_download_updates = false  # if true service will download update and exit
+
+[core]
+    id = "" # id of edge
+    rpc_timeout = "2m" # how long core should wait response from connector before return timeout error
+
+
+    [core.cloud]
+    url = "https://sandbox.rightech.io/api/v1"
+    # cloud jwt access token
+    # minimal scope should be
+    #
+    # GET models/:id
+    # GET objects/:id
+     token = ""  # cloud jwt access token
+
+    [core.mqtt]
+    # if cert_file and key_path provided core will be use tls connection
+    # in this case make sure your url start with tls://
+    url = "tls://sandbox.rightech.io:8883"
+    cert_file = "" # mqtt certificate file path
+    key_path = "" # mqtt key file path
+    
+[opcua]
+    endpoint = "opc.tcp://localhost:4840"
+    encryption = "Basic256Sha256"   # required for encrypted servers only, "Basic256Sha", "Basic256", "Basic128Rsa15" supported
+    mode = "SignAndEncrypt"         # required for encrypted servers only, "None", "Sign", "SignAndEncrypt" supported
+    server_cert = "cert.pem"        # required for encrypted servers only, path to .pem certificate 
+    server_key = "key.pem"          # required for encrypted servers only, path to .pem key 

--- a/assets/snmp-template-config.toml
+++ b/assets/snmp-template-config.toml
@@ -1,0 +1,35 @@
+log_level = "debug"
+log_format = "text" # output log format (you can use text or json)
+auto_download_updates = false  # if true service will download update and exit
+
+[core]
+    id = "" # id of edge
+    rpc_timeout = "2m" # how long core should wait response from connector before return timeout error
+
+
+    [core.cloud]
+    url = "https://sandbox.rightech.io/api/v1"
+    # cloud jwt access token
+    # minimal scope should be
+    #
+    # GET models/:id
+    # GET objects/:id
+    token = ""  # cloud jwt access token
+
+    [core.mqtt]
+    # if cert_file and key_path provided core will be use tls connection
+    # in this case make sure your url start with tls://
+    url = "tls://sandbox.rightech.io:8883"
+    cert_file = "" # mqtt certificate file path
+    key_path = "" # mqtt key file path
+    
+[snmp]
+    host_port="127.0.0.1:161"
+    community=""                  # community string, required for v2c only
+    version=""                    # version of SNMP ("2c" or "3")
+    mode = "authPriv"             # mode of encryption ("authPriv", "authNoPriv", "NoauthNoPriv"), required for v3 only
+    auth_protocol = "MD5"         # "MD5" and "SHA" supported, required for v3 only (if necessary)
+    auth_key = ""                 # required for v3 only (if necessary)
+    priv_protocol = "DES"         # "DES" and "AES" supported, required for v3 only (if necessary)
+    priv_key = ""                 # required for v3 only (if necessary)
+    security_name = ""            # required for v3 only

--- a/internal/app/opcua/config/config.go
+++ b/internal/app/opcua/config/config.go
@@ -27,6 +27,10 @@ import (
 func Setup(version ...string) {
 	config.Init(version)
 
-	viper.Set("opcua.ws_path", "/opcua")
 	viper.SetDefault("opcua.endpoint", "opc.tcp://localhost:4840")
+	viper.SetDefault("opcua.encryption", "")
+	viper.SetDefault("opcua.mode", "None")
+	viper.SetDefault("opcua.server_cert", "")
+	viper.SetDefault("opcua.server_key", "")
+	viper.Set("opcua.ws_path", "/opcua")
 }

--- a/internal/app/opcua/entrypoint/start.go
+++ b/internal/app/opcua/entrypoint/start.go
@@ -28,7 +28,12 @@ import (
 )
 
 func Start(done <-chan os.Signal) error {
-	hand, err := handler.New(viper.GetString("opcua.endpoint"))
+	hand, err := handler.New(
+		viper.GetString("opcua.endpoint"),
+		viper.GetString("opcua.encryption"),
+		viper.GetString("opcua.mode"),
+		viper.GetString("opcua.server_cert"),
+		viper.GetString("opcua.server_key"))
 	if err != nil {
 		return err
 	}

--- a/internal/app/opcua/handler/browse.go
+++ b/internal/app/opcua/handler/browse.go
@@ -29,7 +29,7 @@ import (
 // https://github.com/gopcua/opcua/blob/a2111b07cd2c925c83f0eabd292d8b2747645d11/examples/browse/browse.go
 
 type nodeDef struct {
-	NodeID      *ua.NodeID         `json:"node_id"`
+	NodeID      string             `json:"node_id"`
 	NodeClass   ua.NodeClass       `json:"node_class"`
 	AccessLevel ua.AccessLevelType `json:"access_level"`
 	Writable    bool               `json:"writable"`
@@ -44,7 +44,7 @@ type nodeDef struct {
 }
 
 func (n nodeDef) records() []string {
-	return []string{n.BrowseName, n.DataType, n.NodeID.String(), n.Unit,
+	return []string{n.BrowseName, n.DataType, n.NodeID, n.Unit,
 		n.Scale, n.Min, n.Max, strconv.FormatBool(n.Writable), n.Description}
 }
 
@@ -69,7 +69,7 @@ func browse(n *opcua.Node, path string, level int) ([]nodeDef, error) {
 	}
 
 	var def = nodeDef{
-		NodeID: n.ID,
+		NodeID: n.ID.String(),
 	}
 
 	err = fillStatus(attrs, &def)
@@ -141,6 +141,8 @@ func fillDataType(attrs []*ua.DataValue, def *nodeDef) error {
 			def.DataType = "uint16"
 		case id.UInt32:
 			def.DataType = "uint32"
+		case id.UInt64:
+			def.DataType = "uint64"
 		case id.UtcTime:
 			def.DataType = "time.Time"
 		case id.String:

--- a/internal/app/snmp/config/config.go
+++ b/internal/app/snmp/config/config.go
@@ -30,6 +30,12 @@ func Setup(version ...string) {
 	viper.SetDefault("snmp.host_port", "localhost:161")
 	viper.SetDefault("snmp.version", "2c")
 	viper.SetDefault("snmp.community", "public")
+	viper.SetDefault("snmp.mode", "")
+	viper.SetDefault("snmp.auth_protocol", "")
+	viper.SetDefault("snmp.auth_key", "")
+	viper.SetDefault("snmp.priv_protocol", "")
+	viper.SetDefault("snmp.priv_key", "")
+	viper.SetDefault("snmp.security_name", "")
 
 	viper.Set("snmp.ws_path", "/snmp")
 }

--- a/internal/app/snmp/entrypoint/start.go
+++ b/internal/app/snmp/entrypoint/start.go
@@ -32,7 +32,12 @@ func Start(done <-chan os.Signal) error {
 		viper.GetString("snmp.host_port"),
 		viper.GetString("snmp.community"),
 		viper.GetString("snmp.version"),
-	)
+		viper.GetString("snmp.mode"),
+		viper.GetString("snmp.auth_protocol"),
+		viper.GetString("snmp.auth_key"),
+		viper.GetString("snmp.priv_protocol"),
+		viper.GetString("snmp.priv_key"),
+		viper.GetString("snmp.security_name"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Added SNMP and OPC-UA connectors
SNMP connector was tested on simulated agents (snmp-net and https://github.com/etingof/snmpsim)
OPC-UA was tested on simulated OPC-UA server (https://github.com/FreeOpcUa/python-opcua)
Added config templates for SNMP and OPC-UA to assests folder